### PR TITLE
Wristevator Simulated Motors

### DIFF
--- a/src/main/java/frc/robot/subsystems/Wristevator.java
+++ b/src/main/java/frc/robot/subsystems/Wristevator.java
@@ -9,9 +9,12 @@ import com.ctre.phoenix6.controls.VelocityVoltage;
 import com.ctre.phoenix6.hardware.TalonFX;
 import dev.doglog.DogLog;
 import edu.wpi.first.epilogue.Logged;
+import edu.wpi.first.math.system.plant.DCMotor;
+import edu.wpi.first.math.system.plant.LinearSystemId;
 import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.units.measure.Distance;
 import edu.wpi.first.wpilibj.DigitalInput;
+import edu.wpi.first.wpilibj.simulation.DCMotorSim;
 import edu.wpi.first.wpilibj.simulation.DIOSim;
 import edu.wpi.first.wpilibj.smartdashboard.Mechanism2d;
 import edu.wpi.first.wpilibj.smartdashboard.MechanismLigament2d;
@@ -83,6 +86,8 @@ public class Wristevator extends AdvancedSubsystem {
   private VelocityVoltage _elevatorVelocitySetter = new VelocityVoltage(0);
   private VelocityVoltage _wristVelocitySetter = new VelocityVoltage(0);
 
+  private DCMotorSim _leftMotorSim; 
+
   private final DigitalInput _homeSwitch = new DigitalInput(WristevatorConstants.homeSwitch);
 
   private DIOSim _homeSwitchSim;
@@ -90,8 +95,8 @@ public class Wristevator extends AdvancedSubsystem {
   public Wristevator() {
     if (Robot.isSimulation()) {
       _homeSwitchSim = new DIOSim(_homeSwitch);
-    } else {
-      _homeSwitchSim = null;
+      _leftMotorSim = new DCMotorSim(LinearSystemId.createDCMotorSystem(0, 0), 
+      DCMotor.getKrakenX60(1));
     }
 
     var leftMotorConfigs = new TalonFXConfiguration();


### PR DESCRIPTION
- [x] Create DCMotorSims for each motor required for elevator
- [x] Make the constants for the kV, kA values, but they don't have to be tuned
- [ ] Control the Mechanism2D lengths and angles using the DCMotor Sims

_Code can be found in Phoenix 6 Documentation and in the Intake subsystem_